### PR TITLE
Fix broken links

### DIFF
--- a/manutentore/android/architettura.md
+++ b/manutentore/android/architettura.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Architettura
-parent: Manutentore Android
+parent: Android
 grand_parent: Manuale Manutentore
 nav_order: 3
 ---

--- a/manutentore/android/contribuzione.md
+++ b/manutentore/android/contribuzione.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Contribuzione
-parent: Manutentore Android
+parent: Android
 grand_parent: Manuale Manutentore
 nav_order: 5
 ---

--- a/manutentore/android/index.md
+++ b/manutentore/android/index.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Manutentore Android
+title: Android
 parent: Manuale Manutentore
 has_children: true
 ---

--- a/manutentore/android/installazione.md
+++ b/manutentore/android/installazione.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Installazione
-parent: Manutentore Android
+parent: Android
 grand_parent: Manuale Manutentore
 nav_order: 2
 ---

--- a/manutentore/android/tecnologie.md
+++ b/manutentore/android/tecnologie.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Tecnologie
-parent: Manutentore Android
+parent: Android
 grand_parent: Manuale Manutentore
 nav_order: 1
 ---

--- a/manutentore/android/testing.md
+++ b/manutentore/android/testing.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Testing
-parent: Manutentore Android
+parent: Android
 grand_parent: Manuale Manutentore
 nav_order: 4
 ---

--- a/manutentore/server/architettura.md
+++ b/manutentore/server/architettura.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Architettura
-parent: Manutentore Server
+parent: Server
 grand_parent: Manuale Manutentore
 nav_order: 3
 ---

--- a/manutentore/server/contribuzione.md
+++ b/manutentore/server/contribuzione.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Contribuzione
-parent: Manutentore Server
+parent: Server
 grand_parent: Manuale Manutentore
 nav_order: 5
 ---

--- a/manutentore/server/index.md
+++ b/manutentore/server/index.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Manutentore Server
+title: Server
 parent: Manuale Manutentore
 has_children: true
 ---

--- a/manutentore/server/tecnologie.md
+++ b/manutentore/server/tecnologie.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Tecnologie
-parent: Manutentore Server
+parent: Server
 grand_parent: Manuale Manutentore
 nav_order: 1
 ---

--- a/manutentore/server/testing.md
+++ b/manutentore/server/testing.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Testing
-parent: Manutentore Server
+parent: Server
 grand_parent: Manuale Manutentore
 nav_order: 4
 ---

--- a/manutentore/server/utilizzo.md
+++ b/manutentore/server/utilizzo.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Utilizzo
-parent: Manutentore Server
+parent: Server
 grand_parent: Manuale Manutentore
 nav_order: 2
 ---

--- a/manutentore/web/architettura.md
+++ b/manutentore/web/architettura.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Architettura
-parent: Manutentore Web
+parent: Web
 grand_parent: Manuale Manutentore
 nav_order: 3
 ---

--- a/manutentore/web/contribuzione.md
+++ b/manutentore/web/contribuzione.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Contribuzione
-parent: Manutentore Web
+parent: Web
 grand_parent: Manuale Manutentore
 nav_order: 5
 ---

--- a/manutentore/web/index.md
+++ b/manutentore/web/index.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Manutentore Web
+title: Web
 parent: Manuale Manutentore
 has_children: true
 ---

--- a/manutentore/web/tecnologie.md
+++ b/manutentore/web/tecnologie.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Tecnologie
-parent: Manutentore Web
+parent: Web
 grand_parent: Manuale Manutentore
 nav_order: 1
 ---

--- a/manutentore/web/testing.md
+++ b/manutentore/web/testing.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Testing
-parent: Manutentore Web
+parent: Web
 grand_parent: Manuale Manutentore
 nav_order: 4
 ---

--- a/manutentore/web/utilizzo.md
+++ b/manutentore/web/utilizzo.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Utilizzo
-parent: Manutentore Web
+parent: Web
 grand_parent: Manuale Manutentore
 nav_order: 2
 ---

--- a/utente/android/cleaner.md
+++ b/utente/android/cleaner.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Addetto alle pulizie
-parent: Utente Android
+parent: Android App
 nav_order: 1
 grand_parent: Manuale Utente
 ---

--- a/utente/android/index.md
+++ b/utente/android/index.md
@@ -7,4 +7,4 @@ has_children: true
 
 # Manuale Utente Android
 Il seguente manuale è rivolto agli utilizzatori dell'applicazione Android, ovvero gli utenti e gli addetti alle pulizie. 
-Per informazioni riguardanti il deploy dell'applicazione fare riferimento al [manuale sviluppatore](/manutentore/android.html).
+Per informazioni riguardanti il deploy dell'applicazione fare riferimento al [manuale sviluppatore](/manutentore/android).

--- a/utente/android/index.md
+++ b/utente/android/index.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Utente Android
+title: Android App
 parent: Manuale Utente
 has_children: true
 ---
@@ -8,3 +8,6 @@ has_children: true
 # Manuale Utente Android
 Il seguente manuale è rivolto agli utilizzatori dell'applicazione Android, ovvero gli utenti e gli addetti alle pulizie. 
 Per informazioni riguardanti il deploy dell'applicazione fare riferimento al [manuale sviluppatore](/manutentore/android).
+
+
+

--- a/utente/android/user.md
+++ b/utente/android/user.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Utente
-parent: Utente Android
+parent: Android App
 nav_order: 1
 grand_parent: Manuale Utente
 ---

--- a/utente/server/account.md
+++ b/utente/server/account.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Account
-parent: Utente Server
+parent: API
 nav_order: 1
 grand_parent: Manuale Utente
 ---

--- a/utente/server/index.md
+++ b/utente/server/index.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Utente Server
+title: API
 parent: Manuale Utente
 has_children: true
 ---

--- a/utente/server/prenotazioni.md
+++ b/utente/server/prenotazioni.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Prenotazioni
-parent: Utente Server
+parent: API
 nav_order: 4
 grand_parent: Manuale Utente
 ---

--- a/utente/server/reports.md
+++ b/utente/server/reports.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Reports
-parent: Utente Server
+parent: API
 nav_order: 5
 grand_parent: Manuale Utente
 ---

--- a/utente/server/stanze.md
+++ b/utente/server/stanze.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Stanze
-parent: Utente Server
+parent: API
 nav_order: 3
 grand_parent: Manuale Utente
 ---

--- a/utente/server/utenti.md
+++ b/utente/server/utenti.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Utenti
-parent: Utente Server
+parent: API
 nav_order: 2
 grand_parent: Manuale Utente
 ---


### PR DESCRIPTION
Cambiata la struttura del sito, le pagine utente hanno titoli più significativi mentre le pagine manutentore hanno i nomi dei moduli